### PR TITLE
chore: consolidate dependency updates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -86,7 +86,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Bandit report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: bandit-security-report

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -50,7 +50,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Safety report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: safety-vulnerability-report
@@ -58,7 +58,7 @@ jobs:
         retention-days: 30
 
     - name: Upload pip-audit report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: pip-audit-report

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ matrix-nio==0.25.2
 # hvac>=1.2.0    # For HashiCorp Vault
 
 # Testing dependencies
-pytest==9.0.1
+pytest==9.0.2
 pytest-asyncio==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Python 3.10+
 
 # Core dependencies
-google-genai==1.52.0
+google-genai==1.61.0
 python-dotenv==1.2.1
 doppler-sdk==1.3.0
 


### PR DESCRIPTION
Consolidates dependabot dependency updates into a single PR:

- Bump actions/upload-artifact from 5 to 6
- Bump google-genai to 1.61.0
- Bump pytest to 9.0.2