### PR TITLE
Add macvlan network override example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ dist/
 # Docker
 docker-volumes/
 *.dockerfile.backup
+docker-compose.override.yml
 
 # License
 # This project is licensed under the Mozilla Public License 2.0 (MPL-2.0). See the LICENSE file for details.

--- a/docker-compose.macvlan.example.yml
+++ b/docker-compose.macvlan.example.yml
@@ -1,0 +1,63 @@
+# Macvlan Network Override Example
+# ============================================================
+# Use this to place the bot containers on a macvlan network with
+# static IPs on your LAN. Useful for VLAN segmentation or when
+# you need the bots to appear as their own hosts on the network.
+#
+# Setup:
+#   1. Create the macvlan network (adjust parent/subnet for your LAN):
+#      docker network create -d macvlan \
+#        --subnet=192.168.1.0/24 \
+#        --gateway=192.168.1.1 \
+#        -o parent=eth0 \
+#        my-macvlan
+#
+#   2. Copy this file:
+#      cp docker-compose.macvlan.example.yml docker-compose.override.yml
+#
+#   3. Edit the IP addresses, DNS, and network name to match your setup.
+#
+#   4. Start normally — the override is picked up automatically:
+#      docker compose up -d
+#
+# Note: docker-compose.override.yml is gitignored so your local
+# config won't conflict with upstream updates.
+#
+# === Running both bots in a single container ===
+# The repo compose defines separate Discord and Matrix services.
+# To run both in one container (like production), use this override
+# which disables the split services and adds a combined one:
+# ============================================================
+
+services:
+  # Combined bot running both Discord + Matrix in one container
+  yomama-both:
+    image: ghcr.io/chiefgyk3d/yomama-as-a-service:latest
+    container_name: yomama-both
+    restart: unless-stopped
+    env_file:
+      - .env
+    command: ["python", "main.py", "--discord", "--matrix"]
+    networks:
+      my-macvlan:
+        ipv4_address: 192.168.1.53
+    dns:
+      - 192.168.1.1
+    healthcheck:
+      test: ["CMD", "python", "-c", "import sys; sys.exit(0)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # Disable the split services from the repo compose
+  yomama-discord:
+    profiles:
+      - disabled
+  yomama-matrix:
+    profiles:
+      - disabled
+
+networks:
+  my-macvlan:
+    external: true


### PR DESCRIPTION
Adds `docker-compose.macvlan.example.yml` for deploying the bot on a Docker macvlan network with a static LAN IP.

## What
- New file: `docker-compose.macvlan.example.yml`
- Updated `.gitignore` to exclude `docker-compose.override.yml`

## Usage
1. Create a macvlan Docker network on your host
2. Copy `docker-compose.macvlan.example.yml` to `docker-compose.override.yml`
3. Edit the IP address, DNS, and network name for your environment
4. Run `docker compose up -d` — the override is picked up automatically

## Combined Service
The example includes a `yomama-both` service that runs Discord and Matrix bots in a single container using `--discord --matrix` flags. It also uses `profiles: [disabled]` on the split discord/matrix services so they don't start alongside the combined one.

## Why
Useful for VLAN-segmented setups where the container needs its own IP on the LAN. This is optional — the default bridge networking continues to work as before.